### PR TITLE
fix: label for order comments should be contextual

### DIFF
--- a/includes/class-wcdp-form.php
+++ b/includes/class-wcdp-form.php
@@ -470,7 +470,10 @@ class WCDP_Form
     }
 
     /**
-     * return true if there is a donation form on the site
+     * return true if there is a donation form context on the current page.
+     * Covers: WooCommerce product/checkout pages, Gutenberg block, shortcodes,
+     * and AJAX requests that pass a postid parameter.
+     *
      * @return bool
      */
     public static function wcdp_has_donation_form(): bool
@@ -486,16 +489,30 @@ class WCDP_Form
             || (!is_null($post)
                 && (has_shortcode($post->post_content, 'wcdp_donation_form') || has_shortcode($post->post_content, 'product_page'))
             )
+            || (isset($_REQUEST['postid']) && absint($_REQUEST['postid']) > 0)
         ) {
-            if (!defined('WCDP_FORM')) {
-                define('WCDP_FORM', true);
-            }
+            define('WCDP_FORM', true);
             return true;
         }
         if (!is_null($post)) {
             define('WCDP_FORM', false);
         }
         return false;
+    }
+
+    /**
+     * Return true if the current context is a donation checkout:
+     * either the cart contains only donations, or the page has a donation form.
+     *
+     * @return bool
+     */
+    public static function is_donation_checkout_context(): bool
+    {
+        if (WC()->cart && !empty(WC()->cart->get_cart_contents())) {
+            return self::cart_contains_only_donations();
+        }
+
+        return self::wcdp_has_donation_form();
     }
 
     /**

--- a/includes/class-wcdp-hooks.php
+++ b/includes/class-wcdp-hooks.php
@@ -85,6 +85,32 @@ class WCDP_Hooks
 
         //add Settings Page Link in Backend
         add_action('admin_menu', array($this, 'add_donation_platform_submenu_link'));
+
+        //Add donation-context body classes
+        add_filter('body_class', array($this, 'wcdp_body_classes'));
+    }
+
+    /**
+     * Add donation-context body classes.
+     *
+     * @param array $classes
+     * @return array
+     */
+    public function wcdp_body_classes(array $classes): array
+    {
+        if ($this->has_donation_form_context()) {
+            $classes[] = 'wcdp-donation-form';
+        }
+
+        if ($this->is_donation_checkout_context()) {
+            $classes[] = 'wcdp-donation-checkout';
+        }
+
+        if (is_singular('product') && WCDP_Form::is_donable(get_queried_object_id())) {
+            $classes[] = 'wcdp-donation-product';
+        }
+
+        return $classes;
     }
 
     /**

--- a/includes/class-wcdp-hooks.php
+++ b/includes/class-wcdp-hooks.php
@@ -88,6 +88,34 @@ class WCDP_Hooks
     }
 
     /**
+     * Return true if there is donation form context on the current page.
+     *
+     * @return bool
+     */
+    private function has_donation_form_context(): bool
+    {
+        global $post;
+
+        return has_block('wc-donation-platform/wcdp')
+            || (!is_null($post) && (has_shortcode($post->post_content, 'wcdp_donation_form') || has_shortcode($post->post_content, 'product_page')))
+            || (isset($_REQUEST['postid']) && absint($_REQUEST['postid']) > 0);
+    }
+
+    /**
+     * Return true if donation notes label should be shown.
+     *
+     * @return bool
+     */
+    private function is_donation_checkout_context(): bool
+    {
+        if (WC()->cart && !empty(WC()->cart->get_cart_contents())) {
+            return WCDP_Form::cart_contains_only_donations();
+        }
+
+        return $this->has_donation_form_context();
+    }
+
+    /**
      * Filter specific WC templates to WCDP templates
      *
      * @param string $template
@@ -404,7 +432,7 @@ class WCDP_Hooks
      */
     public function woocommerce_checkout_fields(array $fields): array
     {
-        if (isset($fields['order']['order_comments']) && (WCDP_Form::cart_contains_donation() || (defined('WCDP_FORM') && WCDP_FORM))) {
+        if (isset($fields['order']['order_comments']) && $this->is_donation_checkout_context()) {
             $fields['order']['order_comments']['label'] = __('Donation notes', 'wc-donation-platform');
             $fields['order']['order_comments']['placeholder'] = esc_attr__('Notes about your donation', 'wc-donation-platform');
         }

--- a/includes/class-wcdp-hooks.php
+++ b/includes/class-wcdp-hooks.php
@@ -404,7 +404,7 @@ class WCDP_Hooks
      */
     public function woocommerce_checkout_fields(array $fields): array
     {
-        if (isset($fields['order']['order_comments'])) {
+        if (isset($fields['order']['order_comments']) && WCDP_Form::cart_contains_donation()) {
             $fields['order']['order_comments']['label'] = __('Donation notes', 'wc-donation-platform');
             $fields['order']['order_comments']['placeholder'] = esc_attr__('Notes about your donation', 'wc-donation-platform');
         }

--- a/includes/class-wcdp-hooks.php
+++ b/includes/class-wcdp-hooks.php
@@ -404,7 +404,7 @@ class WCDP_Hooks
      */
     public function woocommerce_checkout_fields(array $fields): array
     {
-        if (isset($fields['order']['order_comments']) && WCDP_Form::cart_contains_donation()) {
+        if (isset($fields['order']['order_comments']) && (WCDP_Form::cart_contains_donation() || (defined('WCDP_FORM') && WCDP_FORM))) {
             $fields['order']['order_comments']['label'] = __('Donation notes', 'wc-donation-platform');
             $fields['order']['order_comments']['placeholder'] = esc_attr__('Notes about your donation', 'wc-donation-platform');
         }

--- a/includes/class-wcdp-hooks.php
+++ b/includes/class-wcdp-hooks.php
@@ -98,11 +98,11 @@ class WCDP_Hooks
      */
     public function wcdp_body_classes(array $classes): array
     {
-        if ($this->has_donation_form_context()) {
+        if (WCDP_Form::wcdp_has_donation_form()) {
             $classes[] = 'wcdp-donation-form';
         }
 
-        if ($this->is_donation_checkout_context()) {
+        if (WCDP_Form::is_donation_checkout_context()) {
             $classes[] = 'wcdp-donation-checkout';
         }
 
@@ -111,34 +111,6 @@ class WCDP_Hooks
         }
 
         return $classes;
-    }
-
-    /**
-     * Return true if there is donation form context on the current page.
-     *
-     * @return bool
-     */
-    private function has_donation_form_context(): bool
-    {
-        global $post;
-
-        return has_block('wc-donation-platform/wcdp')
-            || (!is_null($post) && (has_shortcode($post->post_content, 'wcdp_donation_form') || has_shortcode($post->post_content, 'product_page')))
-            || (isset($_REQUEST['postid']) && absint($_REQUEST['postid']) > 0);
-    }
-
-    /**
-     * Return true if donation notes label should be shown.
-     *
-     * @return bool
-     */
-    private function is_donation_checkout_context(): bool
-    {
-        if (WC()->cart && !empty(WC()->cart->get_cart_contents())) {
-            return WCDP_Form::cart_contains_only_donations();
-        }
-
-        return $this->has_donation_form_context();
     }
 
     /**
@@ -458,7 +430,7 @@ class WCDP_Hooks
      */
     public function woocommerce_checkout_fields(array $fields): array
     {
-        if (isset($fields['order']['order_comments']) && $this->is_donation_checkout_context()) {
+        if (isset($fields['order']['order_comments']) && WCDP_Form::is_donation_checkout_context()) {
             $fields['order']['order_comments']['label'] = __('Donation notes', 'wc-donation-platform');
             $fields['order']['order_comments']['placeholder'] = esc_attr__('Notes about your donation', 'wc-donation-platform');
         }


### PR DESCRIPTION
Love the new contextual labels in 1.4.0

This is the only bug with that we have found so far.
The comment box label says "Donation Notes" all the time at the moment.

This should fix it.