### PR TITLE
add a filter to allow short circuting inline front end CSS

### DIFF
--- a/includes/class-wcdp-form.php
+++ b/includes/class-wcdp-form.php
@@ -409,6 +409,10 @@ class WCDP_Form
      */
     public static function define_ccs_variables()
     {
+        if (!apply_filters('wcdp_should_output_css_vars', true)) {
+            return;
+        }
+
         $wcdp_main_color = get_option('wcdp_secondary_color', '#30bf76');
         $wcdp_main_color_2 = get_option('wcdp_main_color', '#006633');
         $wcdp_main_color_3 = get_option('wcdp_error_color', '#B30000');


### PR DESCRIPTION
We want to build an add on that will remove the color picker fields (already possible) and stop outputting the inline `:root` style block with css vars... that the part that needs this filter.

The idea is for less DIY clients we need to lock down the branding/colors. The inline vars are very hard to override from an enqueued theme css file.