### PR TITLE
fix: clear the write-in "other" field on focus

### DIFF
--- a/assets/js/wcdp.js
+++ b/assets/js/wcdp.js
@@ -452,7 +452,11 @@ jQuery(function ($) {
   //Focus donation amount textfield when "other"-button is selected
   document.querySelectorAll(".wcdp_value_other").forEach((button) => {
     button.addEventListener("click", () => {
-      button.parentElement?.querySelector(".wcdp-input-field")?.focus();
+      const inputField = button.parentElement?.querySelector(".wcdp-input-field");
+      if (inputField) {
+        inputField.focus();
+        inputField.value = '';
+      }
     });
   });
 


### PR DESCRIPTION
This should take care of clearing the other field so the user can start typing their amount right away.

#138 

The's no documentation for compiling .min.js ... plus it looks like the plain .js is enqueued at the moment anyways.