### PR TITLE
feat: add headers for compatibility with git-updater.com

### DIFF
--- a/wc-donation-platform.php
+++ b/wc-donation-platform.php
@@ -6,7 +6,9 @@
  * Author: Jonas Höbenreich
  * Version: 1.4.0
  * Author URI: https://www.jonh.eu/
- * Plugin URI:  https://www.wc-donation.com/
+ * Plugin URI: https://www.wc-donation.com/
+ * GitHub Plugin URI: https://github.com/wc-donation/wc-donation-platform
+ * Primary Branch: main
  * License: GNU General Public License v2.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: wc-donation-platform


### PR DESCRIPTION
I love the [Git Updater](https://git-updater.com/) plugin for working with plugin projects on GitHub.

If you add these headers and install git updater you can do branch switching and refresh the main branch from right inside the WP Dashboard. Also lets you update private repos as if they were on wordpress.org. Good stuff!